### PR TITLE
[MERL-335] build(security): Bump undici to 5.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -784,13 +784,13 @@
       }
     },
     "node_modules/@gqty/cli": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@gqty/cli/-/cli-3.1.0.tgz",
-      "integrity": "sha512-kthyQP+mjUTlnhVT/BYY4RpApXrGas2yDRwSqm1nNnswW5GGPxeDDs2+/ZqUP4QjiuxHe4RKh9dHuKME7QeaTQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@gqty/cli/-/cli-3.3.0.tgz",
+      "integrity": "sha512-V0qJFpxTZBKgqu/Z1sr9WNRosnv58vYeMEVM3ozSrIMhz29DIheUT4cQgs7eF8xFf2+wsbqEp6Rs/yq6z78Yew==",
       "dev": true,
       "dependencies": {
-        "gqty": "^2.1.0",
-        "undici": "^4.12.1"
+        "gqty": "^2.2.0",
+        "undici": "^5.2.0"
       },
       "bin": {
         "gqty": "bin.mjs"
@@ -800,6 +800,11 @@
       },
       "peerDependencies": {
         "graphql": "*"
+      },
+      "peerDependenciesMeta": {
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/@gqty/logger": {
@@ -6511,9 +6516,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.14.1.tgz",
-      "integrity": "sha512-WJ+g+XqiZcATcBaUeluCajqy4pEDcQfK1vy+Fo+bC4/mqXI9IIQD/XWHLS70fkGUT6P52Drm7IFslO651OdLPQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
       "dev": true,
       "engines": {
         "node": ">=12.18"
@@ -7419,13 +7424,13 @@
       }
     },
     "@gqty/cli": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@gqty/cli/-/cli-3.1.0.tgz",
-      "integrity": "sha512-kthyQP+mjUTlnhVT/BYY4RpApXrGas2yDRwSqm1nNnswW5GGPxeDDs2+/ZqUP4QjiuxHe4RKh9dHuKME7QeaTQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@gqty/cli/-/cli-3.3.0.tgz",
+      "integrity": "sha512-V0qJFpxTZBKgqu/Z1sr9WNRosnv58vYeMEVM3ozSrIMhz29DIheUT4cQgs7eF8xFf2+wsbqEp6Rs/yq6z78Yew==",
       "dev": true,
       "requires": {
-        "gqty": "^2.1.0",
-        "undici": "^4.12.1"
+        "gqty": "^2.2.0",
+        "undici": "^5.2.0"
       }
     },
     "@gqty/logger": {
@@ -11730,9 +11735,9 @@
       }
     },
     "undici": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.14.1.tgz",
-      "integrity": "sha512-WJ+g+XqiZcATcBaUeluCajqy4pEDcQfK1vy+Fo+bC4/mqXI9IIQD/XWHLS70fkGUT6P52Drm7IFslO651OdLPQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
       "dev": true
     },
     "uri-js": {


### PR DESCRIPTION
Related ticket: https://wpengine.atlassian.net/browse/MERL-335