### PR TITLE
Add inline ignore from portfolio theme

### DIFF
--- a/src/components/ThemeStyles/ThemeStyles.js
+++ b/src/components/ThemeStyles/ThemeStyles.js
@@ -28,6 +28,7 @@ export default function ThemeStyles() {
   const themeColor = appConfig?.themeColor ?? 'blue';
 
   return (
+    // eslint-disable-next-line react/no-unknown-property
     <style jsx global>{`
       :root {
         --color-black: ${themes[themeColor]['--color-black']};


### PR DESCRIPTION
Signed-off-by: Joe Fusco <joe.fusco@wpengine.com>

These changes introduce an [eslint ignore from the portfolio theme](https://github.com/wpengine/atlas-blueprint-portfolio/blob/main/src/components/ThemeStyles/ThemeStyles.js#L31).

This fixes the build in https://github.com/wpengine/atlas-blueprint-basic/pull/22