### PR TITLE
Added jira key

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @wpengine/merlin
+
+# jira:[18721] is where issues related to this repository should be ticketed


### PR DESCRIPTION
No testing needed- the only check needed by the reviewer is ensuring the team and key is present in the CODEOWNERS file. 